### PR TITLE
Fix warning in y.tab.c

### DIFF
--- a/src/handlebars-objc/parser/handlebars-objc.ym
+++ b/src/handlebars-objc/parser/handlebars-objc.ym
@@ -17,6 +17,7 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
+#pragma clang diagnostic ignored "-Wconditional-uninitialized"
 
 
 %}


### PR DESCRIPTION
Fixes #1 

Disables the warning `Variable 'hb_lval' may be uninitialized when used here` in the generated file `y.tab.c`